### PR TITLE
allow timezone aware datetimes

### DIFF
--- a/pretty_times/pretty.py
+++ b/pretty_times/pretty.py
@@ -2,8 +2,10 @@ from datetime import datetime
 
 __all__ = ("date", )
 
+
 def date(time):
-    now = datetime.now()
+    # calculate "now" in the timezone (if any) of the given time
+    now = datetime.now(time.tzinfo)
 
     if time > now:
         past = False


### PR DESCRIPTION
similar to #1 but uses the given time's tzinfo instead of a UTC class.
also includes a testcase.
