### PR TITLE
allow timezone aware datetimes

### DIFF
--- a/pretty_times/pretty.py
+++ b/pretty_times/pretty.py
@@ -3,7 +3,8 @@ from datetime import datetime
 __all__ = ("date", )
 
 def date(time):
-    now = datetime.now()
+    # calculate "now" in the timezone (if any) of the given time
+    now = datetime.now(time.tzinfo)
 
     if time > now:
         past = False

--- a/pretty_times/tests.py
+++ b/pretty_times/tests.py
@@ -4,7 +4,7 @@ from django.utils import unittest
 from django.template import Template, Context
 from pretty_times import pretty
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, tzinfo
 
 import operator
 
@@ -31,6 +31,18 @@ class PrettyTimeTests(unittest.TestCase):
 
     def test_now(self):
         self.assertEqual("just now", self.apply_prettytime(datetime.today()))
+
+    def test_now_tz(self):
+        """test that non-naive datetimes are handled"""
+        class UTC(tzinfo):
+            """based on example tzinfo classes from:
+            http://docs.python.org/release/2.5.2/lib/datetime-tzinfo.html
+            """
+            def utcoffset(self, dt): return timedelta(0)
+            def dst(self, dt): return timedelta(0)
+
+        dt = datetime.utcnow().replace(tzinfo=UTC())
+        self.assertEqual("just now", self.apply_prettytime(dt))
 
     def test_ten_seconds_ago(self):
         self.assertEqual("10 seconds ago", self.get_past_result(seconds=10))


### PR DESCRIPTION
similar to #1 but uses the given `time`'s tzinfo instead of a UTC class.
also includes a testcase.
