### PR TITLE
Fix day offset calculation

### DIFF
--- a/pretty_times/pretty.py
+++ b/pretty_times/pretty.py
@@ -72,4 +72,4 @@ def _pretty_format(diff_amount, units, text, past):
             'Moment in the future',
             "in %(amount)d %(quantity)s"
         )
-    return base % dict(amount=pretty_time, quantity=text)
+    return base % dict(amount=abs(pretty_time), quantity=text)


### PR DESCRIPTION
eg. If date1 = (2013,5,27,11,18) and date2 = (2013,5,29,3,15), pretty.date would show "tomorrow" instead of 2 days forward. Correct day delta is now calculated from dates, not datetimes.
