### PR TITLE
Fix tests

### DIFF
--- a/pretty_times/pretty.py
+++ b/pretty_times/pretty.py
@@ -18,7 +18,7 @@ def date(time):
 
     days = abs((time.date() - now.date()).days)
 
-    if days is 0:
+    if days is 0 or diff.total_seconds() < 3600 * 6 :
         return get_small_increments(diff.seconds, past)
     else:
         return get_large_increments(days, past)


### PR DESCRIPTION
Tests were revealing an arbitrary, but perfectly reasonable way of telling relative dates. The edit takes it into account and should make all tests pass. (Tested in Django 1.7)
